### PR TITLE
Use `min-height` instead of `height` (add support for manual resize)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -7,16 +7,25 @@ function fitTextarea(textarea: HTMLTextAreaElement): void {
 		positions.set(element, element.scrollTop);
 	}
 
-	// Reset the height to get the smallest possible height
-	textarea.style.minHeight = 'auto';
 	const style = getComputedStyle(textarea);
+	const needsReset = parseInt(style.minHeight, 10) > 0;
+	if (needsReset) {
+		// Reset the height to get the smallest possible height
+		textarea.style.minHeight = '';
+	}
 
-	textarea.style.minHeight = String(textarea.scrollHeight + parseFloat(style.borderTopWidth) + parseFloat(style.borderBottomWidth)) + 'px';
+	const newMinHeight = textarea.scrollHeight + parseFloat(style.borderTopWidth) + parseFloat(style.borderBottomWidth);
+	const needsUpdate = parseInt(style.height, 10) < newMinHeight;
+	if (needsUpdate) {
+		textarea.style.minHeight = `${newMinHeight}px`;
+	}
 
-	// Restore any scrollTop that was lost
-	for (const [element, position] of positions) {
-		if (position && element.scrollTop !== position) {
-			element.scrollTop = position;
+	if (!needsReset) {
+		// Restore any scrollTop that was lost
+		for (const [element, position] of positions) {
+			if (position && element.scrollTop !== position) {
+				element.scrollTop = position;
+			}
 		}
 	}
 }

--- a/index.ts
+++ b/index.ts
@@ -8,10 +8,10 @@ function fitTextarea(textarea: HTMLTextAreaElement): void {
 	}
 
 	// Reset the height to get the smallest possible height
-	textarea.style.height = 'auto';
+	textarea.style.minHeight = 'auto';
 	const style = getComputedStyle(textarea);
 
-	textarea.style.height = String(textarea.scrollHeight + parseFloat(style.borderTopWidth) + parseFloat(style.borderBottomWidth)) + 'px';
+	textarea.style.minHeight = String(textarea.scrollHeight + parseFloat(style.borderTopWidth) + parseFloat(style.borderBottomWidth)) + 'px';
 
 	// Restore any scrollTop that was lost
 	for (const [element, position] of positions) {

--- a/test.js
+++ b/test.js
@@ -19,18 +19,19 @@ test('fit content once (increase)', t => {
 	t.true(textarea.clientHeight >= textarea.scrollHeight);
 });
 
-test.skip('fit content once (keep minimum height)', t => {
+test('fit content once (keep minimum height)', t => {
 	t.plan(1);
-	// TODO: I don't know if this is possible, but the rows attribute and min-height should be followed
-	const textarea = getField(1);
-	textarea.style.minHeight = '200px';
+	const textarea = getField(0);
+	textarea.style.height = '200px';
+	const minimumHeight = getHeight(textarea);
 	fitTextarea(textarea);
-	t.equal(getComputedStyle(textarea).height, '200px');
+	t.equal(getComputedStyle(textarea).height, `${minimumHeight}px`);
 });
 
 test('fit content once + undo when empty', t => {
 	t.plan(1);
 	const textarea = getField();
+	const initialHeight = getHeight(textarea);
 	fitTextarea(textarea);
 	const fitHeight = getHeight(textarea);
 	textarea.value = '';

--- a/test.js
+++ b/test.js
@@ -31,7 +31,7 @@ test('fit content once (keep minimum height)', t => {
 test('fit content once + undo when empty', t => {
 	t.plan(1);
 	const textarea = getField();
-	const initialHeight = getHeight(textarea);
+	// TODO: const initialHeight = getHeight(textarea);
 	fitTextarea(textarea);
 	const fitHeight = getHeight(textarea);
 	textarea.value = '';


### PR DESCRIPTION
Fixes https://github.com/fregante/fit-textarea/issues/9

This needs specific tests (and the logic needs to be fixed, probably)